### PR TITLE
Fix crash when opening notification settings on Android 8+

### DIFF
--- a/app/src/main/java/com/ominous/batterynotification/activity/SettingsActivity.java
+++ b/app/src/main/java/com/ominous/batterynotification/activity/SettingsActivity.java
@@ -211,13 +211,15 @@ public class SettingsActivity extends AppCompatActivity {
             Context context = getContext();
 
             if (context != null && Build.VERSION.SDK_INT > 21) {
-                Intent intent = new Intent("android.settings.APP_NOTIFICATION_SETTINGS");
+                Intent intent = new Intent();
 
                 if (Build.VERSION.SDK_INT > 26) {
-                    intent.putExtra(Settings.EXTRA_APP_PACKAGE, context.getPackageName())
+                    intent.setAction(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
+                            .putExtra(Settings.EXTRA_APP_PACKAGE, context.getPackageName())
                             .putExtra(Settings.EXTRA_CHANNEL_ID, getString(R.string.app_name));
                 } else {
-                    intent.putExtra("app_package", context.getPackageName())
+                    intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                            .putExtra("app_package", context.getPackageName())
                             .putExtra("app_uid", context.getApplicationInfo().uid);
                 }
 


### PR DESCRIPTION
Hello! I discovered your app on F-Droid and I must say I love it.
Unfortunately, after starting the notification, the app crashes when I open the notification settings from it.
After some time, I have discovered that the cause is an Intent with incorrect extras put in. (the Settings.ACTION_APP_NOTIFICATION_SETTINGS action takes only one input (Settings.EXTRA_APP_PACKAGE) but you also put another one (Settings.EXTRA_CHANNEL_ID))
Thus, I have edited the intent to use the correct one (Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS), which I believe you intended to use with those two inputs.